### PR TITLE
Disable nameplate unit by removing GUID

### DIFF
--- a/src/AwesomeWotlkLib/NamePlates.cpp
+++ b/src/AwesomeWotlkLib/NamePlates.cpp
@@ -220,6 +220,7 @@ static void onUpdateCallback()
                 char token[16];
                 snprintf(token, std::size(token), "nameplate%d", i + 1);
                 FrameScript::FireEvent(NAME_PLATE_UNIT_REMOVED, "%s", token);
+                entry.guid = 0;
                 entry.flags &= ~NamePlateFlag_Visible;
             }
         }


### PR DESCRIPTION
Currently, the nameplate unit is still connected to the GUID, allowing it to be used even if the unit is not in nameplate range. It is possible that multiple nameplate units exist for the same GUID if it is reassigned to a different nameplate.